### PR TITLE
Python2+3 way of writing utf8 files

### DIFF
--- a/udapi/core/tests/data/UD_Czech_sample.conllu
+++ b/udapi/core/tests/data/UD_Czech_sample.conllu
@@ -342,3 +342,4 @@
 14	Kanceláří	kancelář	NOUN	NNFS7-----A----	Case=Ins|Gender=Fem|Negative=Pos|Number=Sing	9	ccomp	_	_
 15	SNR	SNR	PROPN	NNFXX-----A---8	Abbr=Yes|Gender=Fem|NameType=Com|Negative=Pos	14	nmod	_	SpaceAfter=No|LId=SNR-1|LGloss=(Slovenská_národní_rada)
 16	.	.	PUNCT	Z:-------------	_	9	punct	_	_
+

--- a/udapi/core/tests/data/secondary_dependencies.conllu
+++ b/udapi/core/tests/data/secondary_dependencies.conllu
@@ -6,3 +6,4 @@
 4	pro	pro	ADP	RR--4----------	AdpType=Prep|Case=Acc	2	appos	0:root	LId=pro-1
 5	i	i	CONJ	J^-------------	_	4	cc	1:amod	LId=i-1
 6	proti	proti	ADP	RR--3----------	AdpType=Prep|Case=Dat	4	conj	5:conj	LId=proti-1
+

--- a/udapi/core/tests/external_tests.sh
+++ b/udapi/core/tests/external_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-udapy read.Conllu filename=data/UD_Czech_sample.conllu write.Conllu filename=out.conllu && diff data/UD_Czech_sample.conllu out.conllu
+udapy read.Conllu filename=data/UD_Czech_sample.conllu write.Conllu > out.conllu && diff data/UD_Czech_sample.conllu out.conllu


### PR DESCRIPTION
Fixes #24.
So now writing to STDOUT works with Python3 as well.
Also, the last line in each conllu file must be empty.