### PR TITLE
fix some pylint errors in zellig-harris

### DIFF
--- a/udapi/block/zellig_harris/common.py
+++ b/udapi/block/zellig_harris/common.py
@@ -1,10 +1,7 @@
-import logging
-import sys
-
-
 def get_node_representation(node, print_lemma=False):
     """
-    Transform the node into the proper textual representation, as will appear in the extracted contexts.
+    Transform the node into the proper textual representation,
+    as will appear in the extracted contexts.
 
     :param node: An input Node.
     :param print_lemma: If true, the node lemma is used, otherwise the node form.

--- a/udapi/block/zellig_harris/configurations.py
+++ b/udapi/block/zellig_harris/configurations.py
@@ -55,8 +55,8 @@ class Configurations(Block):
             methods = globals()
             method = methods.get(query_id)
         except Exception as exception:
-            logging.fatal(' - no such query %s', query_id)
-            sys.exit(1)
+            logging.critical(' - no such query %s', query_id)
+            raise RuntimeError('No such query %s' % query_id)
 
         triples = []
         try:
@@ -64,7 +64,6 @@ class Configurations(Block):
         except ValueError as exception:
             if self.verbose:
                 logging.info(' - no configurations: %s', exception)
-            pass
 
         if len(triples) == 0:
             if self.verbose:

--- a/udapi/block/zellig_harris/csnouns.py
+++ b/udapi/block/zellig_harris/csnouns.py
@@ -13,19 +13,6 @@ class CsNouns(Configurations):
 
     """
 
-    def __init__(self, args=None):
-        """
-        Initialization.
-
-        :param args: A dict of optional parameters.
-
-        """
-        if args is None:
-            args = {}
-
-        # Call the constructor of the parent object.
-        super(CsNouns, self).__init__(args)
-
     def process_node(self, node):
         """
         Extract context configurations for Czech nouns.

--- a/udapi/block/zellig_harris/csverbs.py
+++ b/udapi/block/zellig_harris/csverbs.py
@@ -9,22 +9,9 @@ from udapi.block.zellig_harris.queries import *
 class CsVerbs(Configurations):
     """
     A block for extraction context configurations for Czech verbs.
-    The configurations will be used as the train data for obtaining the word representations using word2vecf.
-
+    The configurations will be used as the train data for obtaining
+    the word representations using word2vecf.
     """
-
-    def __init__(self, args=None):
-        """
-        Initialization.
-
-        :param args: A dict of optional parameters.
-
-        """
-        if args is None:
-            args = {}
-
-        # Call the constructor of the parent object.
-        super(CsVerbs, self).__init__(args)
 
     def process_node(self, node):
         """

--- a/udapi/block/zellig_harris/enhancedeps.py
+++ b/udapi/block/zellig_harris/enhancedeps.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import logging
-
 from udapi.core.block import Block
 
 
@@ -74,28 +72,17 @@ def enhance_deps(node, new_dependence):
 
 class EnhanceDeps(Block):
     """
-    Identify new relations between nodes in the dependency tree (an analogy of effective parents/children from PML).
+    Identify new relations between nodes in the dependency tree
+    (an analogy of effective parents/children from PML).
     Add these new relations into secondary dependencies slot.
 
     """
 
-    def __init__(self, args=None):
-        """
-        Initialization.
-
-        :param args: A dict of optional parameters.
-
-        """
-        super(Block, self).__init__()
-
-        if args is None:
-            args = {}
-
     def process_node(self, node):
         """
         Enhance secondary dependencies by application of the following rules:
-        1. when the current node A has a deprel 'conj' to its parent B, create a new secondary dependence
-           (B.parent, B.deprel) to A
+        1. when the current node A has a deprel 'conj' to its parent B,
+           create a new secondary dependence (B.parent, B.deprel) to A
         2. when the current node A has a deprel 'conj' to its parent B, look at B.children C
            when C.deprel is in {subj, subjpass, iobj, dobj, compl} and there is no A.children D
            such that C.deprel == D.deprel, add a new secondary dependence (A, C.deprel) to C

--- a/udapi/block/zellig_harris/ennouns.py
+++ b/udapi/block/zellig_harris/ennouns.py
@@ -9,22 +9,10 @@ from udapi.block.zellig_harris.queries import *
 class EnNouns(Configurations):
     """
     A block for extraction context configurations for English nouns.
-    The configurations will be used as the train data for obtaining the word representations using word2vecf.
 
+    The configurations will be used as the train data for obtaining
+    the word representations using word2vecf.
     """
-
-    def __init__(self, args=None):
-        """
-        Initialization.
-
-        :param args: A dict of optional parameters.
-
-        """
-        if args is None:
-            args = {}
-
-        # Call the constructor of the parent object.
-        super(EnNouns, self).__init__(args)
 
     def process_node(self, node):
         """

--- a/udapi/block/zellig_harris/enverbs.py
+++ b/udapi/block/zellig_harris/enverbs.py
@@ -9,22 +9,10 @@ from udapi.block.zellig_harris.queries import *
 class EnVerbs(Configurations):
     """
     A block for extraction context configurations for English verbs.
-    The configurations will be used as the train data for obtaining the word representations using word2vecf.
 
+    The configurations will be used as the train data for obtaining
+    the word representations using word2vecf.
     """
-
-    def __init__(self, args=None):
-        """
-        Initialization.
-
-        :param args: A dict of optional parameters.
-
-        """
-        if args is None:
-            args = {}
-
-        # Call the constructor of the parent object.
-        super(EnVerbs, self).__init__(args)
 
     def process_node(self, node):
         """

--- a/udapi/block/zellig_harris/queries.py
+++ b/udapi/block/zellig_harris/queries.py
@@ -1,5 +1,3 @@
-import logging
-
 from udapi.block.zellig_harris.enhancedeps import *
 
 


### PR DESCRIPTION
* the __init__ were wrong (args not used anymore) and moreover not needed
 If there are any extra block parameters, it should be
     def __init__(self, extra_param=default_value, **kwargs):
        super().__init__(**kwargs)
        self.extra_param = extra_param
* configurations.py did not import sys, I think raise is better than sys.exit here
TODO:
* wildcard and unused imports