### PR TITLE
Feats and misc implemented using DualDict

### DIFF
--- a/udapi/block/read/conllu.py
+++ b/udapi/block/read/conllu.py
@@ -71,8 +71,6 @@ class Conllu(BaseReader):
                         parents.append(int(fields[n_attribute]))
                     elif attribute_name == 'ord':
                         setattr(node, 'ord', int(fields[n_attribute]))
-                    elif attribute_name == 'feats':
-                        setattr(node, 'raw_feats', fields[n_attribute])
                     elif attribute_name == 'deps':
                         setattr(node, 'raw_deps', fields[n_attribute])
                     else:

--- a/udapi/block/read/conllu.py
+++ b/udapi/block/read/conllu.py
@@ -99,7 +99,7 @@ class Conllu(BaseReader):
         root._descendants = nodes[1:] # pylint: disable=protected-access
 
         if comment != '':
-            root.misc = comment
+            root.comment = comment
 
         # Create multi-word tokens.
         for fields in mwts:

--- a/udapi/block/read/conllu.py
+++ b/udapi/block/read/conllu.py
@@ -96,7 +96,7 @@ class Conllu(BaseReader):
             node.parent = nodes[parents[node_ord]]
 
         # Set root attributes (descendants for faster iteration of all nodes in a tree).
-        root._descendants = nodes[1:]
+        root._descendants = nodes[1:] # pylint: disable=protected-access
 
         if comment != '':
             root.misc = comment

--- a/udapi/block/write/conllu.py
+++ b/udapi/block/write/conllu.py
@@ -13,7 +13,7 @@ class Conllu(BaseWriter):
 
         # A list of Conllu columns.
         self.node_attributes = ["ord", "form", "lemma", "upos", "xpos",
-                                "raw_feats", "parent", "deprel", "raw_deps", "misc"]
+                                "feats", "parent", "deprel", "raw_deps", "misc"]
 
     def process_tree(self, tree):
         nodes = tree.descendants()

--- a/udapi/block/write/conllu.py
+++ b/udapi/block/write/conllu.py
@@ -31,7 +31,7 @@ class Conllu(BaseWriter):
             if sentence:
                 print("# text = " + sentence)
 
-        comment = tree.misc
+        comment = tree.comment
         if comment:
             comment = comment.rstrip()
             print('#' + comment.replace('\n', '\n#'))

--- a/udapi/block/write/conllu.py
+++ b/udapi/block/write/conllu.py
@@ -1,3 +1,4 @@
+"""Conllu class is a a writer of files in the CoNLL-U format."""
 from udapi.core.basewriter import BaseWriter
 
 
@@ -41,9 +42,9 @@ class Conllu(BaseWriter):
             if mwt and node.ord > last_mwt_id:
                 last_mwt_id = mwt.words[-1].ord
                 print('\t'.join([mwt.ord_range(),
-                                mwt.form if mwt.form is not None else '_',
-                                '_\t_\t_\t_\t_\t_\t_',
-                                mwt.misc if mwt.misc is not None else '_']))
+                                 mwt.form if mwt.form is not None else '_',
+                                 '_\t_\t_\t_\t_\t_\t_',
+                                 mwt.misc if mwt.misc is not None else '_']))
             values = [getattr(node, node_attribute) for node_attribute in self.node_attributes]
             values[0] = str(values[0])
             try:

--- a/udapi/block/write/conllu.py
+++ b/udapi/block/write/conllu.py
@@ -45,8 +45,7 @@ class Conllu(BaseWriter):
                                  mwt.form if mwt.form is not None else '_',
                                  '_\t_\t_\t_\t_\t_\t_',
                                  mwt.misc if mwt.misc is not None else '_']))
-            values = [getattr(node, node_attribute) for node_attribute in self.node_attributes]
-            values[0] = str(values[0])
+            values = [str(getattr(node, attr_name)) for attr_name in self.node_attributes]
             try:
                 values[6] = str(node.parent.ord)
             except AttributeError:

--- a/udapi/block/write/textmodetrees.py
+++ b/udapi/block/write/textmodetrees.py
@@ -110,7 +110,7 @@ class TextModeTrees(BaseWriter):
         self._vert = space + '│'
         self._space = [[space + '├', space + '┌'], [space + '└']]
 
-        self.attrs = [x if x not in ['feats', 'deps'] else 'raw_'+x for x in attributes.split(',')]
+        self.attrs = attributes.split(',')
         self._index_of = []
         self._gaps = []
 

--- a/udapi/core/basereader.py
+++ b/udapi/core/basereader.py
@@ -67,10 +67,8 @@ class BaseReader(Block):
 
         # There may be a tree left in the buffer when reading the last doc.
         if self._buffer:
-            if orig_bundles:
-                bundle = orig_bundles.pop(0)  # TODO inefficient, use collections.deque.popleft()
-            else:
-                bundle = document.create_bundle()
+            # TODO list.pop(0) is inefficient, use collections.deque.popleft()
+            bundle = orig_bundles.pop(0) if orig_bundles else document.create_bundle()
             bundle.add_tree(self._buffer)
             self._buffer = None
 
@@ -92,8 +90,7 @@ class BaseReader(Block):
                 bundle_id = parts[0]
                 if len(parts) == 2:
                     root.zone = parts[1]
-                if bundle_id == last_bundle_id:
-                    add_to_the_last_bundle = 1
+                add_to_the_last_bundle = bundle_id == last_bundle_id
                 last_bundle_id = bundle_id
                 root.sent_id = None
 
@@ -110,7 +107,7 @@ class BaseReader(Block):
                     return
 
                 if orig_bundles:
-                    # TODO inefficient, use collections.deque.popleft()
+                    # TODO list.pop(0) is inefficient, use collections.deque.popleft()
                     bundle = orig_bundles.pop(0)
                     if last_bundle_id and last_bundle_id != bundle.bundle_id:
                         logging.warning('Mismatch in bundle IDs: %s vs %s. Keeping the former one.',

--- a/udapi/core/basewriter.py
+++ b/udapi/core/basewriter.py
@@ -12,7 +12,6 @@ class BaseWriter(Block):
         self.files = Files(filenames=files)
         self.encoding = encoding
         self.newline = newline
-        self.orig_stdout = sys.stdout
 
     def filename(self):
         return self.files.filename()
@@ -25,7 +24,7 @@ class BaseWriter(Block):
 
     def before_process_document(self, _):
         if self.orig_files == '-':
-            sys.stdout = self.orig_stdout
+            sys.stdout = sys.__stdout__
             return
 
         old_filehandle = sys.stdout
@@ -38,7 +37,7 @@ class BaseWriter(Block):
                                % self.orig_files)
         elif filename == '-':
             logging.debug('Opening stdout.')
-            sys.stdout = self.orig_stdout
+            sys.stdout = sys.__stdout__
         else:
             logging.debug('Opening file %s.', filename)
             sys.stdout = open(filename, 'wt', encoding=self.encoding, newline=self.newline)

--- a/udapi/core/dualdict.py
+++ b/udapi/core/dualdict.py
@@ -1,0 +1,76 @@
+"""DualDict is a dict with lazily synchronized string representation."""
+import collections.abc
+
+class DualDict(collections.abc.MutableMapping):
+    """DualDict class serves as dict with lazily synchronized string representation.
+
+    >>> ddict = DualDict('Number=Sing|Person=1')
+    >>> ddict['Case'] = 'Nom'
+    >>> str(ddict)
+    'Case=Nom|Number=Sing|Person=1'
+    >>> ddict['NonExistent']
+    ''
+
+    This class provides access to both
+    * a structured (dict-based, deserialized) representation,
+      e.g. {'Number': 'Sing', 'Person': '1'}, and
+    * a string (serialized) representation of the mapping, e.g. `Number=Sing|Person=1`.
+    There is a clever mechanism that makes sure that users can read and write
+    both of the representations which are always kept synchronized.
+    Moreover, the synchronization is lazy, so the serialization and deserialization
+    is done only when needed. This speeds up scenarios where access to dict is not needed.
+    """
+    __slots__ = ['_string', '_dict']
+
+    def __init__(self, string=None, *args, **kwargs):
+        if string is not None:
+            if args:
+                raise ValueError('If string is specified, no other arg is allowed ' + str(args))
+            if kwargs:
+                raise ValueError('If string is specified, no other kwarg is allowed ' +str(kwargs))
+        self._dict = dict(args, **kwargs)
+        self._string = string
+
+    def __str__(self):
+        if self._string is None:
+            serialized = []
+            for name in sorted(self._dict):
+                serialized.append('%s=%s' % (name, self._dict[name]))
+            self._string = '|'.join(serialized)
+        return self._string
+
+    def _deserialize_if_empty(self):
+        if not self._dict and self._string is not None and self._string != '_':
+            for raw_feature in self._string.split('|'):
+                name, value = raw_feature.split('=')
+                self._dict[name] = value
+
+    def __getitem__(self, key):
+        self._deserialize_if_empty()
+        return self._dict.get(key, '')
+
+    def __setitem__(self, key, value):
+        self._deserialize_if_empty()
+        self._string = None
+        self._dict[key] = value
+
+    def __delitem__(self, key):
+        self._deserialize_if_empty()
+        self._string = None
+        del self._dict[key]
+
+    def __iter__(self):
+        self._deserialize_if_empty()
+        return self._dict.__iter__()
+
+    def __len__(self):
+        self._deserialize_if_empty()
+        return len(self._dict)
+
+    def clear(self):
+        self._string = '_'
+        self._dict.clear()
+
+    def set_string(self, string):
+        self._dict.clear()
+        self._string = string

--- a/udapi/core/dualdict.py
+++ b/udapi/core/dualdict.py
@@ -36,7 +36,7 @@ class DualDict(collections.abc.MutableMapping):
             serialized = []
             for name in sorted(self._dict):
                 serialized.append('%s=%s' % (name, self._dict[name]))
-            self._string = '|'.join(serialized)
+            self._string = '|'.join(serialized) if serialized else '_'
         return self._string
 
     def _deserialize_if_empty(self):
@@ -72,5 +72,6 @@ class DualDict(collections.abc.MutableMapping):
         self._dict.clear()
 
     def set_string(self, string):
+        """Set the mapping from a string serialization."""
         self._dict.clear()
         self._string = string

--- a/udapi/core/dualdict.py
+++ b/udapi/core/dualdict.py
@@ -71,7 +71,23 @@ class DualDict(collections.abc.MutableMapping):
         self._string = '_'
         self._dict.clear()
 
-    def set_string(self, string):
-        """Set the mapping from a string serialization."""
-        self._dict.clear()
-        self._string = string
+    def set_mapping(self, value):
+        """Set the mapping from a dict or string.
+
+        If the `value` is None or an empty string, it is converted to storing string `_`
+        (which is the CoNLL-U way of representing an empty value).
+        If the `value` is a string, it is stored as is.
+        If the `value` is a dict (or any instance of `collections.abc.Mapping`),
+        its copy is stored.
+        Other types of `value` raise an `ValueError` exception.
+        """
+        if value is None:
+            self.clear()
+        elif isinstance(value, str):
+            self._dict.clear()
+            self._string = value if value != '' else '_'
+        elif isinstance(value, collections.abc.Mapping):
+            self._string = None
+            self._dict = dict(value)
+        else:
+            raise ValueError("Unsupported value type " + str(value))

--- a/udapi/core/dualdict.py
+++ b/udapi/core/dualdict.py
@@ -1,5 +1,6 @@
 """DualDict is a dict with lazily synchronized string representation."""
 import collections.abc
+import logging
 
 class DualDict(collections.abc.MutableMapping):
     """DualDict class serves as dict with lazily synchronized string representation.
@@ -42,7 +43,13 @@ class DualDict(collections.abc.MutableMapping):
     def _deserialize_if_empty(self):
         if not self._dict and self._string is not None and self._string != '_':
             for raw_feature in self._string.split('|'):
-                name, value = raw_feature.split('=')
+                try:
+                    name, value = raw_feature.split('=')
+                except ValueError as exception:
+                    logging.error("<%s> contains <%s> which does not contain one '=' symbol.",
+                                  self._string, raw_feature)
+                    raise exception
+
                 self._dict[name] = value
 
     def __getitem__(self, key):

--- a/udapi/core/feats.py
+++ b/udapi/core/feats.py
@@ -1,8 +1,15 @@
 """Feats class for storing morphological features of nodes in UD trees."""
+import udapi.core.dualdict
 
-class Feats(dict):
-    """Feats class for storing morphological features of nodes in UD trees."""
+class Feats(udapi.core.dualdict.DualDict):
+    """Feats class for storing morphological features of nodes in UD trees.
 
-    def __missing__(self, key):
-        """Let the default value be an empty string."""
-        return ''
+    See http://universaldependencies.org/u/feat/index.html for the specification of possible
+    feature names and values.
+    """
+
+    def is_singular(self):
+        return self['Number'].find('Sing') != -1
+
+    def is_plural(self):
+        return self['Number'].find('Plur') != -1

--- a/udapi/core/feats.py
+++ b/udapi/core/feats.py
@@ -9,7 +9,9 @@ class Feats(udapi.core.dualdict.DualDict):
     """
 
     def is_singular(self):
+        """Is the grammatical number singular (feats['Number'] contains 'Sing')?"""
         return self['Number'].find('Sing') != -1
 
     def is_plural(self):
+        """Is the grammatical number plural (feats['Number'] contains 'Plur')?"""
         return self['Number'].find('Plur') != -1

--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -68,11 +68,6 @@ class Node(object):
         return "<%d, %s, %s, %s>" % (self.ord, self.form, parent_ord, self.deprel)
 
     @property
-    def raw_feats(self):
-        """String serialization of morphological features as stored in CoNLL-U files."""
-        return str(self._feats)
-
-    @property
     def feats(self):
         """Return morphological features as a `Feats` object (dict)."""
         return self._feats
@@ -359,16 +354,19 @@ class Node(object):
         """Is this node a leaf, ie. a node without any children?"""
         return not self.children
 
-    def get_attrs(self, attrs, undefs=None):
+    def get_attrs(self, attrs, undefs=None, stringify=True):
         """Return multiple attributes, possibly subsitituting empty ones.
 
         Args:
         attrs: A list of attribute names, e.g. ['form', 'lemma'].
         undefs: A value to be used instead of None for empty (undefined) values.
+        stringify: Apply `str()` on each value (except for None)
         """
         values = [getattr(self, name) for name in attrs]
         if undefs is not None:
             values = [x if x is not None else undefs for x in values]
+        if stringify:
+            values = [str(x) if x is not None else None for x in values]
         return values
 
     def compute_sentence(self):

--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -2,6 +2,7 @@
 import collections.abc
 
 from udapi.block.write.textmodetrees import TextModeTrees
+from udapi.core.dualdict import DualDict
 from udapi.core.feats import Feats
 
 # Pylint complains when we access e.g. node.parent._children or root._descendants
@@ -29,7 +30,7 @@ class Node(object):
         'upos',      # Universal PoS tag
         'xpos',      # Language-specific part-of-speech tag; underscore if not available.
         'deprel',    # UD dependency relation to the HEAD (root iff HEAD = 0).
-        'misc',      # Any other annotation.
+        '_misc',     # Any other annotation as udapi.core.dualdict.DualDict object.
         '_raw_deps', # Enhanced dependencies (head-deprel pairs) in their original CoNLLU format.
         '_deps',     # Deserialized enhanced dependencies in a list of {parent, deprel} dicts.
         '_feats',    # Morphological features as udapi.core.feats.Feats object.
@@ -40,16 +41,13 @@ class Node(object):
 
     def __init__(self, data=None):
         """Create new node and initialize its attributes with data."""
-        # Initialization of the (A) list.
         self.ord = None
         self.form = None
         self.lemma = None
         self.upos = None
         self.xpos = None
         self.deprel = None
-        self.misc = None
-
-        # Initialization of the (B) list.
+        self._misc = DualDict()
         self._raw_deps = '_'
         self._deps = None
         self._feats = Feats()
@@ -86,6 +84,19 @@ class Node(object):
             self._feats.set_string(value)
         elif isinstance(value, collections.abc.Mapping):
             self._feats = Feats(value)
+
+    @property
+    def misc(self):
+        """Return MISC attributes as a `DualDict` object (dict with __str__)."""
+        return self._misc
+
+    @misc.setter
+    def misc(self, value):
+        """Set MISC attributes (the value can be string or dict)."""
+        if isinstance(value, str):
+            self._misc.set_string(value)
+        elif isinstance(value, collections.abc.Mapping):
+            self._misc = DualDict(value)
 
     @property
     def raw_deps(self):

--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -1,6 +1,4 @@
 """Node class represents a node in UD trees."""
-import collections.abc
-
 from udapi.block.write.textmodetrees import TextModeTrees
 from udapi.core.dualdict import DualDict
 from udapi.core.feats import Feats
@@ -69,29 +67,58 @@ class Node(object):
 
     @property
     def feats(self):
-        """Return morphological features as a `Feats` object (dict)."""
+        """Property for morphological features stored as a `Feats` object.
+
+        Reading:
+        You can access `node.feats` as a dict, e.g. `if node.feats['Case'] == 'Nom'`.
+        Features which are not set return an empty string (not None, not KeyError),
+        so you can safely use e.g. `if node.feats['MyExtra'].find('substring') != -1`.
+        You can also obtain the string representation of the whole FEATS (suitable for CoNLL-U),
+        e.g. `if node.feats == 'Case=Nom|Person=1'`.
+
+        Writing:
+        All the following assignment types are supported:
+        `node.feats['Case'] = 'Nom'`
+        `node.feats = {'Case': 'Nom', 'Person': '1'}`
+        `node.feats = 'Case=Nom|Person=1'`
+        `node.feats = '_'`
+        The last line has the same result as assigning None or empty string to `node.feats`.
+
+        For details about the implementation and other methods (e.g. `node.feats.is_plural()`),
+        see ``udapi.core.feats.Feats`` which is a subclass of `DualDict`.
+        """
         return self._feats
 
     @feats.setter
     def feats(self, value):
-        """Set morphological features (the value can be string or dict)."""
-        if isinstance(value, str):
-            self._feats.set_string(value)
-        elif isinstance(value, collections.abc.Mapping):
-            self._feats = Feats(value)
+        self._feats.set_mapping(value)
 
     @property
     def misc(self):
-        """Return MISC attributes as a `DualDict` object (dict with __str__)."""
+        """Property for MISC attributes stored as a `DualDict` object.
+
+        Reading:
+        You can access `node.misc` as a dict, e.g. `if node.misc['SpaceAfter'] == 'No'`.
+        Features which are not set return an empty string (not None, not KeyError),
+        so you can safely use e.g. `if node.misc['MyExtra'].find('substring') != -1`.
+        You can also obtain the string representation of the whole MISC (suitable for CoNLL-U),
+        e.g. `if node.misc == 'SpaceAfter=No|X=Y'`.
+
+        Writing:
+        All the following assignment types are supported:
+        `node.misc['SpaceAfter'] = 'No'`
+        `node.misc = {'SpaceAfter': 'No', 'X': 'Y'}`
+        `node.misc = 'SpaceAfter=No|X=Y'`
+        `node.misc = '_'`
+        The last line has the same result as assigning None or empty string to `node.feats`.
+
+        For details about the implementation, see ``udapi.core.dualdict.DualDict``.
+        """
         return self._misc
 
     @misc.setter
     def misc(self, value):
-        """Set MISC attributes (the value can be string or dict)."""
-        if isinstance(value, str):
-            self._misc.set_string(value)
-        elif isinstance(value, collections.abc.Mapping):
-            self._misc = DualDict(value)
+        self._misc.set_mapping(value)
 
     @property
     def raw_deps(self):

--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -15,13 +15,47 @@ from udapi.core.feats import Feats
 # pylint: disable=too-many-instance-attributes,too-many-public-methods
 
 class Node(object):
-    """Class for representing nodes in Universal Dependency trees."""
+    """Class for representing nodes in Universal Dependency trees.
+
+    Attributes `form`, `lemma`, `upos`, `xpos` and `deprel` are public attributes of type `str`,
+    so you can use e.g. `node.lemma = node.form`.
+
+    `node.ord` is a int type public attribute for storing the node's word order index,
+    but assigning to it should be done with care, so the non-root nodes have `ord`s 1,2,3...
+    It is recommended to use one of the `node.shift_*` methods for reordering nodes.
+
+    For changing dependency structure (topology) of the tree, there is the `parent` property,
+    e.g. `node.parent = node.parent.parent` and `node.create_child()` method.
+    Properties `node.children` and `node.descendants` return object of type `ListOfNodes`,
+    so it is possible to do e.g.
+    >>> all_children = node.children
+    >>> left_children = node.children(preceding_only=True)
+    >>> right_descendants = node.descendants(following_only=True, add_self=True)
+
+    Properties `node.feats` and `node.misc` return objects of type `DualDict`, so one can do e.g.:
+    >>> node = Node()
+    >>> str(node.feats)
+    '_'
+    >>> node.feats = {'Case': 'Nom', 'Person': '1'}`
+    >>> node.feats = 'Case=Nom|Person=1' # equivalent to the above
+    >>> node.feats['Case']
+    'Nom'
+    >>> node.feats['NonExistent']
+    ''
+    >>> node.feats['Case'] = 'Gen'
+    >>> str(node.feats)
+    'Case=Gen|Person=1'
+    >>> dict(node.feats)
+    {'Case': 'Gen', 'Person': '1'}
+
+    Handling of enhanced dependencies, multi-word tokens and other node's methods
+    are described below.
+    """
 
     # TODO: Benchmark memory and speed of slots vs. classic dict.
     # With Python 3.5 split dict, slots may not be better.
     # TODO: Should not we include __weakref__ in slots?
     __slots__ = [
-        # Word index, integer starting at 1 for each new sentence.
         'ord',       # Word-order index of the node (root has 0).
         'form',      # Word form or punctuation symbol.
         'lemma',     # Lemma of word form.

--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -23,22 +23,19 @@ class Node(object):
     # TODO: Should not we include __weakref__ in slots?
     __slots__ = [
         # Word index, integer starting at 1 for each new sentence.
-        'ord',
-        'form',    # Word form or punctuation symbol.
-        'lemma',   # Lemma of word form.
-        'upos', # Universal PoS tag
-        'xpos', # Language-specific part-of-speech tag; underscore if not available.
-        'deprel',  # UD dependency relation to the HEAD (root iff HEAD = 0).
-        'misc',    # Any other annotation.
-
-        # Enhanced dependencies (head-deprel pairs) in their original CoNLLU format.
-        '_raw_deps',
-        # Deserialized enhanced dependencies in a list of {parent, deprel} dicts.
-        '_deps',
-        '_feats',      # Morphological features as udapi.core.feats.Feats object.
-        '_parent',     # Parent node.
-        '_children',   # Ord-ordered list of child nodes.
-        '_mwt',        # multi-word token in which this word participates
+        'ord',       # Word-order index of the node (root has 0).
+        'form',      # Word form or punctuation symbol.
+        'lemma',     # Lemma of word form.
+        'upos',      # Universal PoS tag
+        'xpos',      # Language-specific part-of-speech tag; underscore if not available.
+        'deprel',    # UD dependency relation to the HEAD (root iff HEAD = 0).
+        'misc',      # Any other annotation.
+        '_raw_deps', # Enhanced dependencies (head-deprel pairs) in their original CoNLLU format.
+        '_deps',     # Deserialized enhanced dependencies in a list of {parent, deprel} dicts.
+        '_feats',    # Morphological features as udapi.core.feats.Feats object.
+        '_parent',   # Parent node.
+        '_children', # Ord-ordered list of child nodes.
+        '_mwt',      # multi-word token in which this word participates
     ]
 
     def __init__(self, data=None):

--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -35,10 +35,7 @@ class Node(object):
         '_raw_deps',
         # Deserialized enhanced dependencies in a list of {parent, deprel} dicts.
         '_deps',
-        # Morphological features in their original CoNLLU format.
-        '_raw_feats',
-        # Deserialized morphological features stored in a dict (feature -> value).
-        '_feats',
+        '_feats',      # Morphological features as udapi.core.feats.Feats object.
         '_parent',     # Parent node.
         '_children',   # Ord-ordered list of child nodes.
         '_mwt',        # multi-word token in which this word participates
@@ -58,7 +55,6 @@ class Node(object):
         # Initialization of the (B) list.
         self._raw_deps = '_'
         self._deps = None
-        self._raw_feats = '_'
         self._feats = Feats()
         self._parent = None
         self._children = list()

--- a/udapi/core/root.py
+++ b/udapi/core/root.py
@@ -8,9 +8,9 @@ from udapi.core.mwt import MWT
 
 class Root(Node):
     """Class for representing root nodes (technical roots) in UD trees."""
-    __slots__ = ['_sent_id', '_zone', '_bundle', '_descendants', '_mwts', 'text']
+    __slots__ = ['_sent_id', '_zone', '_bundle', '_descendants', '_mwts', 'text', 'comment']
 
-    def __init__(self, sent_id=None, zone=None, misc=None, text=None):
+    def __init__(self, sent_id=None, zone=None, comment=None, text=None):
         """Create new root node."""
         # Call constructor of the parent object.
         super().__init__()
@@ -21,7 +21,7 @@ class Root(Node):
         self.upos = '<ROOT>'
         self.xpos = '<ROOT>'
         self.deprel = '<ROOT>'
-        self.misc = misc
+        self.comment = comment
         self.text = text
 
         self._sent_id = sent_id

--- a/udapi/core/tests/test_node.py
+++ b/udapi/core/tests/test_node.py
@@ -82,12 +82,19 @@ class TestDocument(unittest.TestCase):
             root.print_subtree(color=False, attributes='form,feats,misc')
             self.assertEqual(capture.getvalue(), expected2)
         finally:
-            sys.stdout = sys.__stdout__
+            sys.stdout = sys.__stdout__ # pylint: disable=redefined-variable-type
 
     def test_feats(self):
         """Test the morphological featrues."""
         node = Node()
         self.assertEqual(str(node.feats), '_')
+        node.feats = ''
+        self.assertEqual(str(node.feats), '_')
+        node.feats = None
+        self.assertEqual(str(node.feats), '_')
+        node.feats = {} # pylint: disable=redefined-variable-type
+        self.assertEqual(str(node.feats), '_')
+
         node.feats = 'Mood=Ind|Person=1|Voice=Act'
         self.assertEqual(node.feats['Mood'], 'Ind')
         self.assertEqual(node.feats['Voice'], 'Act')

--- a/udapi/core/tests/test_node.py
+++ b/udapi/core/tests/test_node.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+"""Unit tests for udapi.core.node."""
 import os
 import unittest
 import logging
@@ -14,8 +14,10 @@ logging.basicConfig(
 
 
 class TestDocument(unittest.TestCase):
+    """Unit tests for udapi.core.node."""
 
     def test_topology(self):
+        """Test methods/properties descendants, children, prev_node, next_node, ord."""
         doc = Document()
         data_filename = os.path.join(os.path.dirname(__file__), 'data', 'enh_deps.conllu')
         doc.load_conllu(data_filename)
@@ -54,6 +56,7 @@ class TestDocument(unittest.TestCase):
         expected_feats = 'Mood=Ind|Person=1|Voice=Pas'
 
         node = Node()
+        self.assertEqual(str(node.feats), '_')
         node.feats = raw_feats
         self.assertEqual(node.feats['Voice'], 'Act')
         self.assertEqual(node.feats['Mood'], 'Ind')
@@ -69,10 +72,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(node.feats, {})
 
     def test_deps_getter(self):
-        """
-        Test the deserialization of the morphological featrues.
-
-        """
+        """Test enhanced dependencies."""
         # Create a path to the test CoNLLU file.
         data_filename = os.path.join(os.path.dirname(__file__), 'data', 'enh_deps.conllu')
 
@@ -103,10 +103,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(nodes[5].deps[0]['parent'], nodes[4])
 
     def test_deps_setter(self):
-        """
-        Test the deserialization of the secondary dependencies.
-
-        """
+        """Test the deserialization of enhanced dependencies."""
         # Create a sample dependency tree.
         root = Root()
         for _ in range(3):

--- a/udapi/core/tests/test_node.py
+++ b/udapi/core/tests/test_node.py
@@ -47,42 +47,26 @@ class TestDocument(unittest.TestCase):
         #self.assertEqual([node.ord for node in nodes], [2, 1, 3, 4, 5, 6])
         #self.assertEqual([node.ord for node in root.descendants()], [1, 2, 3, 4, 5, 6])
 
-    def test_feats_getter(self):
-        """
-        Test the deserialization of the morphological featrues.
 
-        """
+    def test_feats(self):
+        """Test the morphological featrues."""
+        raw_feats = 'Mood=Ind|Person=1|Voice=Act'
+        expected_feats = 'Mood=Ind|Person=1|Voice=Pas'
+
         node = Node()
-        node.raw_feats = 'Mood=Ind|Negative=Pos|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin'
+        node.feats = raw_feats
+        self.assertEqual(node.feats['Voice'], 'Act')
         self.assertEqual(node.feats['Mood'], 'Ind')
-        self.assertEqual(node.feats['Negative'], 'Pos')
-        self.assertEqual(node.feats['Number'], 'Sing')
-        self.assertEqual(node.feats['Person'], '1')
-        self.assertEqual(node.feats['Tense'], 'Pres')
-        self.assertEqual(node.feats['VerbForm'], 'Fin')
-        node.raw_feats = '_'
-        self.assertEqual(node.feats, {})
+        self.assertEqual(node.feats['NonExistentFeature'], '')
 
-    def test_feats_setter(self):
-        """
-        Test the deserialization of the morphological featrues.
-
-        """
-        raw_feats = 'Mood=Ind|Negative=Pos|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin|Voice=Act'
-        expected_feats = 'Mood=Ind|Negative=Pos|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin|Voice=Pas'
-
-        node = Node()
-        node.raw_feats = raw_feats
         node.feats['Voice'] = 'Pas'
-
-        self.assertEqual(node.feats['Mood'], 'Ind')
-        self.assertEqual(node.feats['Negative'], 'Pos')
-        self.assertEqual(node.feats['Number'], 'Sing')
-        self.assertEqual(node.feats['Person'], '1')
-        self.assertEqual(node.feats['Tense'], 'Pres')
-        self.assertEqual(node.feats['VerbForm'], 'Fin')
-        self.assertEqual(node.feats['Voice'], 'Pas')
         self.assertEqual(node.raw_feats, expected_feats)
+        self.assertEqual(node.feats['Voice'], 'Pas')
+        self.assertEqual(node.feats['Mood'], 'Ind')
+        self.assertEqual(node.feats['Person'], '1')
+
+        node.feats = '_'
+        self.assertEqual(node.feats, {})
 
     def test_deps_getter(self):
         """
@@ -125,7 +109,7 @@ class TestDocument(unittest.TestCase):
         """
         # Create a sample dependency tree.
         root = Root()
-        for i in range(3):
+        for _ in range(3):
             root.create_child()
 
         nodes = root.descendants()


### PR DESCRIPTION
```python
>>> node = Node()
>>> str(node.feats)
'_'
>>> node.feats = {'Case': 'Nom', 'Person': '1'}`
>>> node.feats = 'Case=Nom|Person=1' # equivalent to the above
>>> node.feats['Case']
'Nom'
>>> node.feats['NonExistent']
''
>>> node.feats['Case'] = 'Gen'
>>> str(node.feats)
'Case=Gen|Person=1'
>>> dict(node.feats)
{'Case': 'Gen', 'Person': '1'}
```
`node.misc` works the same as `node.feats`, only `feats` will have few more syntactic sugar methods, e.g. `node.feats.is_plural()`.

This way, we don't need `node.raw_feats`.