### PR TITLE
Compound:prt is for Germanic languages only

### DIFF
--- a/udapi/block/ud/google2ud.py
+++ b/udapi/block/ud/google2ud.py
@@ -16,7 +16,7 @@ from udapi.block.ud.pt.addmwt import AddMwt as pt_AddMwt
 DEPREL_CHANGE = {
     "ROOT": "root",
     "prep": "case",
-    "ncomp": "case",  # TODO ?
+    "ncomp": "case:loc",  # only in Chinese; Herman proposes case:loc
     "p": "punct",
     "poss": "nmod:poss",
     "ps": "case",
@@ -32,9 +32,9 @@ DEPREL_CHANGE = {
     "gobj": "obj",
     "postneg": "neg",  # will be changed to advmod + Polarity=Neg in ud.Convert1to2
     "pronl": "obj",  # TODO: or expl? UD_French seems to use a mix of both
-    "redup": "compound:plur",
+    "redup": "compound:plur",  # TODO: compound:plur in Indonesian; compound:redup elsewhere
     "oblcomp": "obl",
-    "mes": "dep",  # TODO ?
+    "mes": "clf",  # TODO: structural transformation needed
     "mwn": "compound:n",  # nominal multi-word
     "mwa": "compound:a",  # adjectival multi-word
     "mwv": "compound:v",  # verbal multi-word

--- a/udapi/block/ud/google2ud.py
+++ b/udapi/block/ud/google2ud.py
@@ -26,7 +26,6 @@ DEPREL_CHANGE = {
     "vmod": "acl",
     "rcmod": "acl:relcl",
     "npadvmod": "advmod",
-    "prt": "compound:prt",
     "preconj": "cc:preconj",
     "predet": "det:predet",
     "gobj": "obj",
@@ -472,5 +471,7 @@ class Google2ud(Convert1to2):
         elif node.deprel == 'appos':
             if self.lang == 'fr' and node.parent.form in {'M.', 'Mme', 'Dr'}:
                 node.deprel = 'flat:name'
+        elif node.deprel == 'prt':
+            node.deprel = 'compound:prt' if self.lang in {'en', 'de', 'nl', 'sv', 'da', 'no'} else 'dep:prt'
         elif node.deprel == 'redup':
             node.deprel = 'compound:plur' if self.lang == 'id' else 'compound:redup'


### PR DESCRIPTION
I do not know a universal solution so I suggest to use `dep:prt` elsewhere to not lose the annotation and be able to act later.