### PR TITLE
Francesco Mambrini

### DIFF
--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -195,7 +195,9 @@ class Node(object):
         if self._deps is not None:
             serialized_deps = []
             for secondary_dependence in self._deps:
-                serialized_deps.append('%d:%s' % (secondary_dependence[
+                # serialized_deps.append('%d:%s' % (secondary_dependence[
+                #    'parent'].ord, secondary_dependence['deprel']))
+                serialized_deps.append('{}:{}'.format(secondary_dependence[
                     'parent'].ord, secondary_dependence['deprel']))
             self._raw_deps = '|'.join(serialized_deps)
         return self._raw_deps

--- a/udapi/core/node.py
+++ b/udapi/core/node.py
@@ -195,8 +195,6 @@ class Node(object):
         if self._deps is not None:
             serialized_deps = []
             for secondary_dependence in self._deps:
-                # serialized_deps.append('%d:%s' % (secondary_dependence[
-                #    'parent'].ord, secondary_dependence['deprel']))
                 serialized_deps.append('{}:{}'.format(secondary_dependence[
                     'parent'].ord, secondary_dependence['deprel']))
             self._raw_deps = '|'.join(serialized_deps)

--- a/udapi/core/tests/test_enhdeps.py
+++ b/udapi/core/tests/test_enhdeps.py
@@ -1,0 +1,62 @@
+import unittest
+import os
+import udapi
+
+from udapi.core.root import Root
+from udapi.core.node import Node, find_minimal_common_treelet
+from udapi.core.document import Document
+from udapi.block.read.conllu import Conllu as ConlluReader
+from udapi.block.write.conllu import Conllu as ConlluWriter
+
+
+class TestEnhDeps(unittest.TestCase):
+    """Unit tests for udapi.core.node and enhanced dependecies.
+    Tests the behaviour with empty nodes (with decimal ord, such as 0.1, 2.3 etc.) as well"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = Document()
+        cls.data = os.path.join(os.path.dirname(udapi.__file__), "core", "tests", "data", "enh_deps.conllu")
+        cls.doc.load_conllu(cls.data)
+        cls.tree = cls.doc.bundles[0].get_tree()
+        cls.nodes = cls.tree.descendants
+        cls.add_empty_node(cls.tree, 3)
+
+    @staticmethod
+    def add_empty_node(tree, ord_before, decimal=1):
+        """Add an empty node to tree after the node with index `ord_before`.
+        Empty node will receive ord=`ord_before`.`decimal`"""
+        e = tree.create_empty_child()
+        e.ord = float('{}.{}'.format(ord_before, decimal))
+        e.form = "E{}".format(e.ord)
+
+    def test_datapath(self):
+        self.assertTrue(os.path.isfile(self.data))
+
+    def test_nodes(self):
+        self.assertEqual(6, len(self.nodes))
+
+    def test_ord_type(self):
+        self.assertIsNot(str, type(self.nodes[0].ord))
+
+    def test_create_empty(self):
+        writer = ConlluWriter()
+        writer.apply_on_document(self.doc)
+        # self.tree.print_subtree()
+        self.assertGreater(len(self.tree.empty_nodes), 0)
+
+    def test_regular_deps(self):
+
+        n = self.nodes[0]
+        self.assertEqual("0:root|2:amod", n.raw_deps)
+
+    def test_create_deps2empty(self):
+        e = self.tree.empty_nodes[0]
+        h = self.nodes[1]
+        d = self.nodes[5]
+        e.deps.append({'parent': h, 'deprel':'dep:e2h'})
+        d.deps.append({'parent': e, 'deprel': 'dep:d2e'})
+        self.assertEqual("2:dep:e2h", e.raw_deps, )
+        self.assertEqual("5:conj|3.1:dep:d2e", d.raw_deps)
+
+


### PR DESCRIPTION
Simple fix to [Issue 62](https://github.com/udapi/udapi-python/issues/62). The fix is minimal and trivial: replace the modulo `%d` operator with `"{}:{}".format()` in the function that creates the `raw_deps` (Python 3 is already a requirement for `udapi-python`).

I tested the fix with:
* `core/tests/test_nodes.py`
* `core/tests/test_enhdeps.py` (created by me)