### PR TITLE
make Udapi easier to use from IPython

### DIFF
--- a/udapi/__init__.py
+++ b/udapi/__init__.py
@@ -1,0 +1,1 @@
+from .core.document import Document

--- a/udapi/__init__.py
+++ b/udapi/__init__.py
@@ -1,1 +1,2 @@
 from .core.document import Document
+from .core.run import create_block

--- a/udapi/core/block.py
+++ b/udapi/core/block.py
@@ -38,6 +38,11 @@ class Block(object):
             if self._should_process_tree(tree):
                 self.process_tree(tree)
 
+    def run(self, document):
+        self.process_start()
+        self.apply_on_document(document)
+        self.process_end()
+
     def apply_on_document(self, document):
         self.before_process_document(document)
         self.process_document(document)

--- a/udapi/core/document.py
+++ b/udapi/core/document.py
@@ -4,19 +4,34 @@ import io
 from udapi.core.bundle import Bundle
 from udapi.block.read.conllu import Conllu as ConlluReader
 from udapi.block.write.conllu import Conllu as ConlluWriter
+from udapi.block.read.sentences import Sentences as SentencesReader
 
 
 class Document(object):
     """Document is a container for Universal Dependency trees."""
 
     def __init__(self, filename=None):
-        """Create a new Udapi document. Optionally, load the CoNLL-U file specified in `filename`."""
+        """Create a new Udapi document.
+
+        Args:
+        filename: load the specified file.
+            Only `*.conlu` (using `udapi.block.read.conllu`)
+            and `*.txt` (using `udapi.block.read.sentences`) filenames are supported.
+            No pre-processing is applied, so when loading the document from a *.txt file,
+            `Document("a.txt").nodes` will be empty and you need to run tokenization first.
+        """
         self.bundles = []
         self._highest_bundle_id = 0
         self.meta = {}
         self.json = {}
         if filename is not None:
-            self.load_conllu(filename)
+            if filename.endswith(".conllu"):
+                self.load_conllu(filename)
+            elif filename.endswith(".txt"):
+                reader = SentencesReader(files=filename)
+                reader.apply_on_document(self)
+            else:
+                raise ValueError("Only *.conllu and *.txt are supported. Provided: " + filename)
 
     def __iter__(self):
         return iter(self.bundles)

--- a/udapi/core/document.py
+++ b/udapi/core/document.py
@@ -9,11 +9,14 @@ from udapi.block.write.conllu import Conllu as ConlluWriter
 class Document(object):
     """Document is a container for Universal Dependency trees."""
 
-    def __init__(self):
+    def __init__(self, filename=None):
+        """Create a new Udapi document. Optionally, load the CoNLL-U file specified in `filename`."""
         self.bundles = []
         self._highest_bundle_id = 0
         self.meta = {}
         self.json = {}
+        if filename is not None:
+            self.load_conllu(filename)
 
     def __iter__(self):
         return iter(self.bundles)
@@ -47,3 +50,18 @@ class Document(object):
         writer = ConlluWriter(filehandle=fh)
         writer.apply_on_document(self)
         return fh.getvalue()
+
+    @property
+    def trees(self):
+        """An iterator over all trees in the document."""
+        for bundle in self:
+            for tree in bundle:
+                yield tree
+
+    @property
+    def nodes(self):
+        """An iterator over all nodes in the document."""
+        for bundle in self:
+            for tree in bundle:
+                for node in tree.descendants:
+                    yield node

--- a/udapi/core/run.py
+++ b/udapi/core/run.py
@@ -171,3 +171,9 @@ class Run(object):
     def scenario_string(self):
         """Return the scenario string."""
         return "\n".join(self.args.scenario)
+
+
+def create_block(block, **kwargs):
+    """A factory function for creating new block instances (handy for IPython)."""
+    blocks = _import_blocks([block], [kwargs])
+    return blocks[0]


### PR DESCRIPTION
For example to print subjects with more than 4 children:
```
import udapi
doc = udapi.Document("UD_English/sample.conllu")
subjects = [n for n in doc.nodes if n.deprel == 'nsubj']
for subject in subjects:
     if len(subject.children) > 4:
         subject.print_subtree()
```