### PR TITLE
If resegment=False, the root.text should not contain only the first sentence

### DIFF
--- a/udapi/tool/udpipe.py
+++ b/udapi/tool/udpipe.py
@@ -1,5 +1,6 @@
 """Wrapper for UDPipe (more pythonic than ufal.udpipe)."""
 import io
+import sys
 
 from ufal.udpipe import Model, Pipeline, ProcessingError, Sentence  # pylint: disable=no-name-in-module
 from udapi.core.resource import require_file
@@ -92,7 +93,7 @@ class UDPipe:
         for u_sentence in u_sentences:
             if not new_root:
                 new_root = Root()
-            new_root.text = u_sentence.getText()
+            new_root.text = u_sentence.getText() if resegment else root.text
             heads, nodes = [], [new_root]
             u_words = u_sentence.words
             for i in range(1, u_words.size()):


### PR DESCRIPTION
Calling `tokenize_tag_parse_tree` with `resegment=False` first runs the underlying UDPipe, resulting in a sequence of tokens potentially grouped to sentence segments. The nested sequence is then flatten so that all tokens belong to the same segment. However, this was not reflected in the `root.text` attribute, which was always assigned a value from UDPipe by calling `ufal.udpipe.Sentence.getText()`. Apparently, instead of recomputing the return value on the fly, the getter returns a value pre-computed during processing.

If we do not want the text to be resegmented, the value of `root.text` must stay the same.