### PR TITLE
Whitespaces can be stored in the conllu file, so that the original text can be reconstructed back

### DIFF
--- a/udapi/block/tokenize/onwhitespace.py
+++ b/udapi/block/tokenize/onwhitespace.py
@@ -30,6 +30,8 @@ class OnWhitespace(Block):
         preserve whitespaces by filling MISC attributes `SpacesAfter` and `SpacesBefore` (by default True)
     """
 
+    escape_whitespace_table = str.maketrans({' ':r'\s', '\t':r'\t', '\r':r'\r', '\n':r'\n'})
+
     def __init__(self, normalize_spaces=True, **kwargs):
         super().__init__(**kwargs)
         self.normalize_spaces = normalize_spaces
@@ -38,14 +40,6 @@ class OnWhitespace(Block):
     def tokenize_sentence(string):
         """A method to be overriden in subclasses."""
         return string.split()
-
-    @staticmethod
-    def escape_whitespace(string):
-        string = re.sub(r' ', r'\\s', string)
-        string = re.sub(r'\t', r'\\t', string)
-        string = re.sub(r'\r', r'\\r', string)
-        string = re.sub(r'\n', r'\\n', string)
-        return string
 
     def process_tree(self, root):
         if root.children:
@@ -95,9 +89,9 @@ class OnWhitespace(Block):
             node = root.create_child(form=token)
             node.ord = i
 
-            if i == 1 and len(spaces_before) > 0:
-                node.misc["SpacesBefore"] = self.escape_whitespace(spaces_before)
-            if not len(spaces_after):
+            if i == 1 and spaces_before:
+                node.misc["SpacesBefore"] = spaces_before.translate(escape_whitespace_table)
+            if not spaces_after:
                 node.misc["SpaceAfter"] = 'No'
             elif spaces_after != " ":
-                node.misc["SpacesAfter"] = self.escape_whitespace(spaces_after)
+                node.misc["SpacesAfter"] = spaces_after.translate(escape_whitespace_table)

--- a/udapi/block/tokenize/onwhitespace.py
+++ b/udapi/block/tokenize/onwhitespace.py
@@ -15,6 +15,14 @@ class OnWhitespace(Block):
         """A method to be overriden in subclasses."""
         return string.split()
 
+    @staticmethod
+    def escape_whitespace(string):
+        string = re.sub(r' ', r'\\s', string)
+        string = re.sub(r'\t', r'\\t', string)
+        string = re.sub(r'\r', r'\\r', string)
+        string = re.sub(r'\n', r'\\n', string)
+        return string
+
     def process_tree(self, root):
         if root.children:
             raise ValueError('Tree %s is already tokenized.' % root)
@@ -58,8 +66,8 @@ class OnWhitespace(Block):
             node.ord = i
 
             if i == 1 and len(spaces_before) > 0:
-                node.misc["SpacesBefore"] = spaces_before
+                node.misc["SpacesBefore"] = self.escape_whitespace(spaces_before)
             if not len(spaces_after):
                 node.misc["SpaceAfter"] = 'No'
             elif spaces_after != ' ':
-                node.misc["SpacesAfter"] = spaces_after
+                node.misc["SpacesAfter"] = self.escape_whitespace(spaces_after)

--- a/udapi/block/tokenize/onwhitespace.py
+++ b/udapi/block/tokenize/onwhitespace.py
@@ -90,8 +90,8 @@ class OnWhitespace(Block):
             node.ord = i
 
             if i == 1 and spaces_before:
-                node.misc["SpacesBefore"] = spaces_before.translate(escape_whitespace_table)
+                node.misc["SpacesBefore"] = spaces_before.translate(self.escape_whitespace_table)
             if not spaces_after:
                 node.misc["SpaceAfter"] = 'No'
             elif spaces_after != " ":
-                node.misc["SpacesAfter"] = spaces_after.translate(escape_whitespace_table)
+                node.misc["SpacesAfter"] = spaces_after.translate(self.escape_whitespace_table)


### PR DESCRIPTION
Use the parameter `normalize_spaces=False` to preserve all whitespaces in the sentence in the UDPipe way, i.e. using the `SpacesAfter` and `SpacesBefore` features in the MISC field. It is backward compatible with CoNLL-U v2 `SpaceAfter=No` feature. That is, a missing space after the token is marked by `SpaceAfter=No`, even if it follows the last token of the sentence, and a single space after the token results in no whitespace-related markup at all.

Examples:
```
$> echo -e "Hello \t world " | udapy read.Sentences $'rstrip=\r\n' tokenize.OnWhitespace normalize_spaces=0 write.Conllu
# sent_id = 1
# text = Hello   world
1       Hello   _       _       _       _       0       _       _       SpacesAfter=\s\t\s
2       world   _       _       _       _       0       _       _       _

$> echo -e "Hello \t world" | udapy read.Sentences $'rstrip=\r\n' tokenize.OnWhitespace normalize_spaces=0 write.Conllu
# sent_id = 1
# text = Hello   world
1       Hello   _       _       _       _       0       _       _       SpacesAfter=\s\t\s
2       world   _       _       _       _       0       _       _       SpaceAfter=No 

$> echo -e "\tHello \t world" | udapy read.Sentences $'rstrip=\r\n' tokenize.OnWhitespace normalize_spaces=0 write.Conllu
# sent_id = 1
# text =        Hello    world
1       Hello   _       _       _       _       0       _       _       SpacesAfter=\s\t\s|SpacesBefore=\t
2       world   _       _       _       _       0       _       _       SpaceAfter=No

$> echo -e "\tHello \t world " | udapy read.Sentences $'rstrip=\r\n' tokenize.OnWhitespace write.Conllu 
# sent_id = 1
# text =        Hello    world 
1       Hello   _       _       _       _       0       _       _       _
2       world   _       _       _       _       0       _       _       _

```
Note that if loading the text using `read.Sentences` and all whitespaces need to be preserved (in order to be able to reconstruct the original document), the `read.Sentences` block must be called with `rstrip=\n` or `rstrip=\r\n` to prevent stripping the trailing whitespace.