### PR TITLE
Improvements to Simple segmenter

### DIFF
--- a/udapi/block/segment/simple.py
+++ b/udapi/block/segment/simple.py
@@ -4,7 +4,20 @@ from udapi.core.bundle import Bundle
 import re
 
 class Simple(Block):
-    """"Heuristic segmenter, splits on sentence-final segmentation followed by uppercase."""
+    """"Heuristic segmenter, splits on sentence-final segmentation followed by uppercase.
+        The exceptions are:
+            1) abbreviations of names, e.g. "A. Merkel"
+            2) predefined list of nonfinal abbreviations, e.g. "e.g."
+
+        Parameters
+        ----------
+        keep_spaces : bool
+            do not strip whitespaces from the `text` attribute of the sentences created by segmentation
+    """
+    
+    def __init__(self, keep_spaces=False, **kwargs):
+        super().__init__(**kwargs)
+        self.keep_spaces = keep_spaces
 
     @staticmethod
     def is_nonfinal_abbrev(token):
@@ -44,7 +57,8 @@ class Simple(Block):
         segments = [previous]
         for token in tokens[1:]:
             if self.is_boundary(previous, token):
-                segments[-1] += ' '
+                if self.keep_spaces:
+                    segments[-1] += ' '
                 segments.append(token)
             else:
                 segments[-1] += ' ' + token

--- a/udapi/block/segment/simple.py
+++ b/udapi/block/segment/simple.py
@@ -16,6 +16,8 @@ class Simple(Block):
 
     def is_boundary(self, first, second):
         """Is there a sentence boundary between the first and second token?"""
+        if not first or not second:
+            return False
         if first[-1] in '"“»›)':
             first = first[:-1]
         if second[0] in '"„«¿¡‹(':
@@ -25,6 +27,9 @@ class Simple(Block):
         if not first[-1] in '.!?':
             return False
         if first[-1] == '.':
+            # correctly count length in "„A. Merkel"
+            if first[0] in '"„«¿¡‹(':
+                first = first[1:]
             if len(first) == 2 and first[0].isupper():
                 return False
             if self.is_nonfinal_abbrev(first[:-1]):
@@ -39,6 +44,7 @@ class Simple(Block):
         segments = [previous]
         for token in tokens[1:]:
             if self.is_boundary(previous, token):
+                segments[-1] += ' '
                 segments.append(token)
             else:
                 segments[-1] += ' ' + token


### PR DESCRIPTION
1. deal with multiple consecutive spaces in input sentences or the space at the start/end of the sentence
    => no sentence boundary
2. do not strip possible trailing space from the sentence. When applying tokenize.Simple afterwards with normalize_spaces=0, it correctly fills the whitespace-related MISC features => the text can be reconstructed in its original form
3. if an abbreviation of the first name is the first word of a quoted segment, delete the starting quotation mark to find out if the word consists of two chars, e.g. in "„A. Merkel ..."