### PR TITLE
Adjustments to correctly work with texts loaded with whitespace included

### DIFF
--- a/udapi/block/read/sentences.py
+++ b/udapi/block/read/sentences.py
@@ -12,7 +12,9 @@ class Sentences(BaseReader):
     rstrip: a set of characters to be stripped from the end of each line.
         Default='\r\n '. You can use rstrip='\n' if you want to preserve
         any space or '\r' (Carriage Return) at end of line,
-        so that `udpipe.Base resegment=1` keeps these characters in `SpacesAfter`.
+        so that `udpipe.Base` keeps these characters in `SpacesAfter`.
+        As most blocks do not expect whitespace other than a space to appear
+        in the processed text, using this feature is at your own risk.
     """
     def __init__(self, ignore_empty_lines=False, rstrip='\r\n ', **kwargs):
         self.ignore_empty_lines = ignore_empty_lines

--- a/udapi/block/tokenize/onwhitespace.py
+++ b/udapi/block/tokenize/onwhitespace.py
@@ -32,7 +32,7 @@ class OnWhitespace(Block):
 
     escape_whitespace_table = str.maketrans({' ':r'\s', '\t':r'\t', '\r':r'\r', '\n':r'\n'})
 
-    def __init__(self, keep_spaces=True, **kwargs):
+    def __init__(self, keep_spaces=False, **kwargs):
         super().__init__(**kwargs)
         self.keep_spaces = keep_spaces
 

--- a/udapi/block/tokenize/onwhitespace.py
+++ b/udapi/block/tokenize/onwhitespace.py
@@ -6,16 +6,16 @@ from udapi.core.block import Block
 class OnWhitespace(Block):
     """Base tokenizer, splits on whitespaces, fills SpaceAfter=No.
 
-    Use the parameter `normalize_spaces=False` to preserve all whitespaces in the sentence
+    Use the parameter `keep_spaces=True` to preserve all whitespaces in the sentence
     in the UDPipe way, i.e. using the `SpacesAfter` and `SpacesBefore` features in the MISC field.
     It is backward compatible with CoNLL-U v2 `SpaceAfter=No` feature. That is, no following
     whitespace is marked by `SpaceAfter=No` and a single following space results in no
     whitespace-related markup.
     If loading the text using `read.Sentences` and all whitespaces need to be preserved
     (in order to be able to reconstruct the original document), the `read.Sentences` block
-    must be called with `rstrip=\n` or `rstrip=\r\n` to prevent stripping the trailing
-    whitespace, e.g.::
-        $> echo -e "Hello \t world " | udapy read.Sentences $'rstrip=\r\n' tokenize.OnWhitespace normalize_spaces=0 write.Conllu
+    must be called with `rstrip=''`, `rstrip=\n` or `rstrip=\r\n` to prevent stripping the
+    trailing whitespace, e.g.::
+        $> echo -e "Hello \t world " | udapy read.Sentences $'rstrip=\r\n' tokenize.OnWhitespace keep_spaces=1 write.Conllu
 
         # sent_id = 1
         # text = Hello   world
@@ -26,15 +26,15 @@ class OnWhitespace(Block):
 
     Parameters
     ----------
-    normalize_spaces : bool
-        preserve whitespaces by filling MISC attributes `SpacesAfter` and `SpacesBefore` (by default True)
+    keep_spaces : bool
+        preserve whitespaces by filling MISC attributes `SpacesAfter` and `SpacesBefore` (by default False)
     """
 
     escape_whitespace_table = str.maketrans({' ':r'\s', '\t':r'\t', '\r':r'\r', '\n':r'\n'})
 
-    def __init__(self, normalize_spaces=True, **kwargs):
+    def __init__(self, keep_spaces=True, **kwargs):
         super().__init__(**kwargs)
-        self.normalize_spaces = normalize_spaces
+        self.keep_spaces = keep_spaces
 
     @staticmethod
     def tokenize_sentence(string):
@@ -80,7 +80,7 @@ class OnWhitespace(Block):
                 sentence = sentence[len(spaces_after):]
 
             # normalize whitespace
-            if self.normalize_spaces:
+            if not self.keep_spaces:
                 spaces_before = ""
                 # spaces_after = "" <=> SpaceAfter=No is never set for the last token <=> len(sentence) = 0
                 spaces_after = "" if not len(spaces_after) and len(sentence) else " "

--- a/udapi/block/write/conllu.py
+++ b/udapi/block/write/conllu.py
@@ -2,8 +2,6 @@
 import json
 from udapi.core.basewriter import BaseWriter
 
-escape_whitespace_table = str.maketrans({'\r':'', '\n':''})
-
 class Conllu(BaseWriter):
     """A writer of files in the CoNLL-U format."""
 
@@ -33,7 +31,7 @@ class Conllu(BaseWriter):
             print('# sent_id = ' + tree.sent_id)
 
         if self.print_text:
-            print('# text = ' + (tree.compute_text() if tree.text is None else tree.text.translate(escape_whitespace_table).rstrip()))
+            print('# text = ' + (tree.compute_text() if tree.text is None else tree.text.replace('\n', '').replace('\r', '').rstrip()))
 
         if tree.json:
             for key, value in sorted(tree.json.items()):

--- a/udapi/block/write/conllu.py
+++ b/udapi/block/write/conllu.py
@@ -2,6 +2,7 @@
 import json
 from udapi.core.basewriter import BaseWriter
 
+escape_whitespace_table = str.maketrans({'\r':'', '\n':''})
 
 class Conllu(BaseWriter):
     """A writer of files in the CoNLL-U format."""
@@ -32,7 +33,7 @@ class Conllu(BaseWriter):
             print('# sent_id = ' + tree.sent_id)
 
         if self.print_text:
-            print('# text = ' + (tree.text or tree.compute_text()))
+            print('# text = ' + (tree.compute_text() if tree.text is None else tree.text.translate(escape_whitespace_table).rstrip()))
 
         if tree.json:
             for key, value in sorted(tree.json.items()):


### PR DESCRIPTION
These changes are related only to the documents that are read using `read.Sentences` with parameter `rstrip=''`, `rstrip='\n'` or `rstrip='\r\n'`.

1. The most important is preventing printing out the unescaped whitespace by `write.Conllu`. It has been already implemented that if `tokenize.OnWhitespace keep_spaces=1` or `udpipe.Base` is used, the whitespace is escaped and preserved in MISC features `SpaceAfter`, `SpacesAfter` and `SpacesBefore`. Here we address the `Root.text` attribute, which contains all whitespaces in the unescaped form throughout whole processing. These, however, need to be removed or escaped during writing to CoNLL-U format. **We have now decided to remove all '\n' and '\r' from the whole `Root.text` attribute and strip the whitespaces from its end.** Multiple spaces or tabs between the tokens are thus kept and printed out with `write.Conllu`.
2.  A warning of using the `rstrip=''` parameter was put to its documentation.
3. The parameter `normalize_spaces` in `tokenize.OnWhitespace` renamed to `keep_spaces` with `False` as a default value (instead of the previous `True`).