### PR TITLE
Bugfix: coref must be loaded also from empty nodes

### DIFF
--- a/udapi/core/coref.py
+++ b/udapi/core/coref.py
@@ -182,7 +182,6 @@ def load_coref_from_misc(doc):
     clusters = {}
     for tree in doc.trees:
         for node in tree.descendants_and_empty:
-            print(node.ord)
             index, index_str = 0, ""
             cluster_id = node.misc["ClusterId"]
             if not cluster_id:


### PR DESCRIPTION
`doc.nodes` iterates only over overt nodes, which results in no coreference information loaded for empty nodes.
This fixes it, as iteration over `doc.nodes` is replaced with an iteration over `doc.trees` and a nested iteration over `tree.descendants_and_empty`. Another way to fix it is to introduce a method of the `Document` class that would do the same.

I have replaced it in two places to ensure that the following actions are performed even for the empty nodes:
1. `load_coref_from_misc`: ensures that coreference is loaded from MISC
2. `store_coref_to_misc`: ensures that previous coreference-related MISC features are deleted before writing the new ones