### PR TITLE
Corefhtml writer: use a relative docs_dir path in the JS script

### DIFF
--- a/udapi/block/write/corefhtml.py
+++ b/udapi/block/write/corefhtml.py
@@ -177,6 +177,10 @@ class CorefHtml(BaseWriter):
         self.colors = colors
         if docs_dir != '.' and not os.path.exists(docs_dir):
             os.makedirs(docs_dir)
+        new_dir, new_filename = os.path.split(self.path)
+        self.js_docs_dir = docs_dir
+        if docs_dir.startswith(new_dir):
+            self.js_docs_dir = os.path.relpath(docs_dir, new_dir)
         self._mention_ids = {}
         self._entity_colors = {}
 
@@ -274,7 +278,7 @@ class CorefHtml(BaseWriter):
         finally:
             sys.stdout = orig_stdout
 
-        print(f'<script>\nvar all_docs = {len(ud_docs)};\nvar docs_dir = "{self.docs_dir}";')
+        print(f'<script>\nvar all_docs = {len(ud_docs)};\nvar docs_dir = "{self.js_docs_dir}";')
         print(SCRIPT_BASE)
         if self.show_trees:
             print('docs_json = [false, ', end='') # 1-based index, so dummy docs_json[0]

--- a/udapi/block/write/corefhtml.py
+++ b/udapi/block/write/corefhtml.py
@@ -181,8 +181,6 @@ class CorefHtml(BaseWriter):
             self.docs_dir = os.path.join(new_dir, docs_dir)
         if docs_dir != '.' and not os.path.exists(self.docs_dir):
             os.makedirs(self.docs_dir)
-        print(f"DOCS_DIR: {self.docs_dir}", file=sys.stderr)
-        print(f"JS_DOCS_DIR: {self.js_docs_dir}", file=sys.stderr)
         self._mention_ids = {}
         self._entity_colors = {}
 

--- a/udapi/block/write/corefhtml.py
+++ b/udapi/block/write/corefhtml.py
@@ -170,17 +170,19 @@ class CorefHtml(BaseWriter):
 
     def __init__(self, docs_dir='docs', show_trees=True, show_eid=False, show_etype=False, colors=7, **kwargs):
         super().__init__(**kwargs)
-        self.docs_dir = docs_dir
         self.show_trees = show_trees
         self.show_eid = show_eid
         self.show_etype = show_etype
         self.colors = colors
-        if docs_dir != '.' and not os.path.exists(docs_dir):
-            os.makedirs(docs_dir)
-        new_dir, new_filename = os.path.split(self.path)
         self.js_docs_dir = docs_dir
-        if docs_dir.startswith(new_dir):
-            self.js_docs_dir = os.path.relpath(docs_dir, new_dir)
+        self.docs_dir = docs_dir
+        if self.path:
+            new_dir, _ = os.path.split(self.path)
+            self.docs_dir = os.path.join(new_dir, docs_dir)
+        if docs_dir != '.' and not os.path.exists(self.docs_dir):
+            os.makedirs(self.docs_dir)
+        print(f"DOCS_DIR: {self.docs_dir}", file=sys.stderr)
+        print(f"JS_DOCS_DIR: {self.js_docs_dir}", file=sys.stderr)
         self._mention_ids = {}
         self._entity_colors = {}
 

--- a/udapi/core/basewriter.py
+++ b/udapi/core/basewriter.py
@@ -10,7 +10,7 @@ from udapi.core.files import Files
 
 
 class BaseWriter(Block):
-    """Base class for all reader blocks."""
+    """Base class for all writer blocks."""
 
     def __init__(self, files='-', filehandle=None, docname_as_file=False, encoding='utf-8',
                  newline='\n', overwrite=False, path=None, **kwargs):


### PR DESCRIPTION
### Issue description:
In the `write.corefhtml` package, the `docs_dir` parameter is supposed to contain a path relative to the directory where the HTML file is output. However, this is violated when the output directory is not the current working directory.

### Fix description:
The fix introduces `js_docs_dir` which should always contain a relative path to be used in the JS scripts. On the other hand, if the output directory is specified using the `path` parameter, the `docs_dir` is adjusted so that it is relative to the output path.

### TODO:
For the time being, it only works if the `path` parameter is specified. It is not adjusted if the output directory is specified using the `files` parameter.