### PR TITLE
Recursively searching for non-empty ancestors of enhanced dependencies with empty parents

### DIFF
--- a/udapi/block/corefud/delete.py
+++ b/udapi/block/corefud/delete.py
@@ -10,19 +10,43 @@ class Delete(Block):
         super().__init__(**kwargs)
         self.empty = empty
 
+
+    def _deps_ignore_nodes(self, node, parents_to_ignore):
+        """ Retrieve deps from the node, recursively ignoring specified parents.
+        """
+        newdeps = []
+        stack = [(node, [])]
+        while stack:
+            proc_node, skipped_nodes = stack.pop()
+            # if there is a cycle of skipped nodes, ground the subtree to the root
+            if proc_node in skipped_nodes:
+                newdeps.append({'parent': node.root, 'deprel': 'root'})
+                continue
+            for dep in proc_node.deps:
+                # keep deps with a parent that shouldn't be ignored
+                if not dep['parent'] in parents_to_ignore:
+                    newdeps.append(dep)
+                    continue
+                # process the ignored parent recursively
+                stack.append((dep['parent'], skipped_nodes + [proc_node]))
+        return newdeps
+
     def process_document(self, doc):
         # This block should work both with coreference loaded (deserialized) and not.
         doc._eid_to_entity = None
         for root in doc.trees:
             if self.empty:
-                root.empty_nodes = []
                 for node in root.descendants:
-                    if node.raw_deps != '_':
-                        node.raw_deps = '|'.join(d for d in node.raw_deps.split('|') if not '.' in d)
-                        if node.raw_deps == '':
-                            node.raw_deps = '0:root'
+                    # process only the nodes dependent on empty nodes
+                    if not '.' in node.raw_deps:
+                        continue
+                    newdeps = self._deps_ignore_nodes(node, root.empty_nodes)
+                    newdeps_sorted = sorted(set((dep['parent'].ord, dep['deprel']) for dep in newdeps))
+                    node.raw_deps = '|'.join(f"{p}:{r}" for p, r in newdeps_sorted)
+
                     if '.' in node.misc['Functor'].split(':')[0]:
                         del node.misc['Functor']
+                root.empty_nodes = []
 
             for node in root.descendants + root.empty_nodes:
                 node._mentions = []


### PR DESCRIPTION
The current solution of deleting enhanced dependencies (`deps` field) to empty parents fails in validation tests with a few error of the following type:
```
[(in cs_pcedt-ud-test-blind.conllu) Line 62051 Sent wsj2387-001-p1s47]: [L2 Enhanced unconnected-egraph] Enhanced graph is not connected. Nodes ['34', '35', '36', '37', '38', '39', '40', '41'] are not reachable from any root
Enhanced errors: 1
*** FAILED *** with 1 errors
```
The reason is that it just deletes the dependencies to empty parents and replaces them with a dependency to "0:root" only if no other has left. However, exceptionally it happens that a dependency to an empty parent is the only connection of a set of nodes to the rest of the tree, making them unreachable from the root after deleting the empty parent. 

The suggested solution first checks if the root remains reachable after deletion of all empty nodes. If yes, it just removes the empty-parent dependencies. Otherwise, it tries to replace the dependency to an empty parent with the empty parent's dependencies. If these deps also contain an empty-parent dependency, replacing is recursively repeated to the ancestors until all dependencies point to non-empty parents. If no non-empty parents can be found during this procedure (a cycle is encountered), the problematic dependency is replaced with `0:root`.