### PR TITLE
Split the execute method in Run

### DIFF
--- a/udapi/core/run.py
+++ b/udapi/core/run.py
@@ -165,6 +165,9 @@ class Run(object):
         # Import blocks (classes) and construct block instances.
         blocks = _import_blocks(block_names, block_args)
 
+        return self.run_blocks(blocks)
+
+    def run_blocks(self, blocks):
         # Initialize blocks (process_start).
         for bname, block in blocks:
             block.process_start()


### PR DESCRIPTION
Factoring out the execution of blocks from the `Run.execute` will allow users to run their scenarios from Python and use user-initialized blocks directly without the need to parse string scenarios.