### PR TITLE
End index mismatch in read.AddText

### DIFF
--- a/udapi/block/read/addtext.py
+++ b/udapi/block/read/addtext.py
@@ -32,7 +32,7 @@ class AddText(BaseReader):
             self.finished = True
             return
         text = ''.join(self.filehandle.readlines())
-        i, end, was_newpar = 0, len(text), True
+        i, end, was_newpar = 0, len(text)-1, True
         while i <= end and text[i].isspace():
             i += 1
 


### PR DESCRIPTION
- fixing the value of the `end` variable - the index of the text end
    - this should match with all the conditions where `end` is used
- discovered while aligning FantasyCoref with its original texts
- TODO: should be checked if the update doesn't violate processing of LitBank, for which the block was originally designed for